### PR TITLE
Fix hero scrollbar appearing if scrollbars are forced to be on

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -32,10 +32,6 @@ header nav {
   transition: transform .3s ease, height .3s ease, background .3s ease,opacity .3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-header nav[aria-expanded="true"] {
-  overflow-y: auto;
-}
-
 header .wide {
   height: var(--nav-height);
   grid-template:


### PR DESCRIPTION
@cziegeler, our fix from yesterday was not complete as we missed an overflow setting that was overriding our rule. Can you check if it works correctly with this PR?

Test URLs:
- Before: https://main--sazerac-wheatleyvodka--hlxsites.hlx.page/
- After: https://hero-scrollbar--sazerac-wheatleyvodka--hlxsites.hlx.page/
